### PR TITLE
feat: 按 job 配置通知策略（notify 写入 neutron.yaml）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,6 @@ go test ./...
 - `GET /api/status/:jobName` — job/pod status (JSON, from DB for completed jobs or K8s API for active jobs)
 - `POST /api/report/:jobName` — runners push status back to API server for persistence
 - `POST /api/report/:jobName/link` — set a test report URL for a job (`{"report_url": "..."}`)
-- `GET/POST/DELETE /api/projects/:id/recipients` — manage IM notification recipients (per-user)
-- `GET/POST/DELETE /api/projects/:id/ccwebhooks` — manage CCWork group webhook URLs (per-project)
 - SPA: `cmd/api/static/index.html` — vanilla JS with hash-based routing (#/, #/projects, #/project/:id, #/status/:name)
 
 **GitLab Runner** (`cmd/gitlab-runner/`) — runs inside K8s pods for GitLab projects:
@@ -78,10 +76,8 @@ go test ./...
 
 Tables auto-migrated by GORM:
 - `neutron_project` (id, webhook_type, repo_url)
-- `neutron_job` (id, project_id, name, status, completed, completed_at)
+- `neutron_job` (id, project_id, name, status, notify, completed, completed_at) — `notify` is JSON-encoded `model.Notify` captured from the job's `neutron.yaml` at trigger time
 - `neutron_pod` (id, job_id, pod_name, pod_uid, phase)
-- `neutron_notify` (id, project_id, user_id) — IM notification recipients per project
-- `neutron_ccwebhook` (id, project_id, webhook_url, description) — CCWork group webhooks per project
 - `neutron_job_report` (id, job_name, report_url, created_at) — test report link per job
 
 ### Configuration
@@ -90,11 +86,24 @@ Runtime config is `config.yaml` (gitignored). Shape defined by `internal/model/c
 
 ### Notifications
 
-Two notification channels, always sent in parallel on pipeline trigger and completion:
-1. **IM notifications** (`internal/notify/`) — sends to individual users via enterprise IM bot API. Recipients managed per project in `neutron_notify` table.
-2. **CCWork group webhooks** (`internal/ccwork/`) — sends to group chats via webhook URLs. Webhooks managed per project in `neutron_ccwebhook` table, each with a description label.
+Notifications are configured **per job** in the repository's `neutron.yaml`, under each job's optional `notify` block:
 
-Both use structured attachment format with title (head) and body content.
+```yaml
+jobs:
+  build:
+    trigger: [PUSH, MR]
+    notify:
+      users:  [zhangsan, lisi]                          # IM personal-message recipients (user ids)
+      groups: ["https://ccwork.example.com/robot/send?key=..."]  # CCWork group robot webhook URLs
+```
+
+Two channels, sent in parallel (fire-and-forget) on pipeline trigger and completion for each job that declares targets:
+1. **IM notifications** (`internal/notify/`) — sends to individual users via enterprise IM bot API (`notify.users`).
+2. **CCWork group webhooks** (`internal/ccwork/`) — sends to group chats via webhook URLs (`notify.groups`).
+
+Both use structured attachment format with title (head) and body content. A job with no `notify` block sends nothing.
+
+The config is parsed at trigger time and persisted as JSON on `neutron_job.notify`, so the completion handler (`POST /api/report/:jobName`, which only knows the job name) can read the same targets back via the `GetJobByName` lookup it already performs — see `sendJobNotifications` / `marshalNotify` / `parseNotify` in `cmd/api/`.
 
 ### Webhook URL Parameters
 

--- a/cmd/api/notify.go
+++ b/cmd/api/notify.go
@@ -2,24 +2,26 @@ package main
 
 import (
 	"neutron/internal/ccwork"
+	"neutron/internal/model"
 )
 
-// sendNotifications fans a title/content message out to both notification
-// channels configured for a project: per-user IM messages and CCWork group
-// webhooks. Each send runs in its own goroutine, matching the original
-// fire-and-forget semantics.
-func (s *Server) sendNotifications(projectId, title, content string) {
+// sendJobNotifications fans a title/content message out to a job's configured
+// notification targets: IM personal messages for each user, and CCWork group
+// robot webhooks for each group URL. Each send runs in its own goroutine,
+// preserving fire-and-forget semantics. A nil or empty Notify sends nothing.
+func (s *Server) sendJobNotifications(n *model.Notify, title, content string) {
+	if n == nil {
+		return
+	}
 	if s.notifyClient != nil {
-		if recipients, err := s.repo.ListNotifyRecipients(projectId); err == nil {
-			for _, r := range recipients {
-				go s.notifyClient.SendMessage(r.UserId, title, content)
-			}
+		for _, u := range n.Users {
+			go s.notifyClient.SendMessage(u, title, content)
 		}
 	}
-	if webhooks, err := s.repo.ListCCWebhooks(projectId); err == nil && len(webhooks) > 0 {
-		ccWebhooks := make([]ccwork.Webhook, len(webhooks))
-		for i, w := range webhooks {
-			ccWebhooks[i] = ccwork.Webhook{Url: w.WebhookUrl, Description: w.Description}
+	if len(n.Groups) > 0 {
+		ccWebhooks := make([]ccwork.Webhook, len(n.Groups))
+		for i, url := range n.Groups {
+			ccWebhooks[i] = ccwork.Webhook{Url: url}
 		}
 		go s.ccworkRobot.SendToAll(ccWebhooks, title, content)
 	}

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -53,12 +53,6 @@ func (s *Server) registerRoutes(r *gin.Engine) {
 	r.GET("/api/projects", s.handleListProjects)
 	r.GET("/api/projects/:id/jobs", s.handleListProjectJobs)
 	r.GET("/api/jobs/recent", s.handleRecentJobs)
-	r.GET("/api/projects/:id/recipients", s.handleListRecipients)
-	r.POST("/api/projects/:id/recipients", s.handleAddRecipient)
-	r.DELETE("/api/projects/:id/recipients/:rid", s.handleRemoveRecipient)
-	r.GET("/api/projects/:id/ccwebhooks", s.handleListCCWebhooks)
-	r.POST("/api/projects/:id/ccwebhooks", s.handleAddCCWebhook)
-	r.DELETE("/api/projects/:id/ccwebhooks/:wid", s.handleRemoveCCWebhook)
 	r.POST("/api/register", s.handleRegister)
 	r.GET("/api/status/:jobName", s.handleStatus)
 	r.POST("/api/report/:jobName", s.handleReport)
@@ -106,95 +100,6 @@ func (s *Server) handleRecentJobs(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"jobs": jobs})
-}
-
-func (s *Server) handleListRecipients(c *gin.Context) {
-	id := c.Param("id")
-	recipients, err := s.repo.ListNotifyRecipients(id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"recipients": recipients})
-}
-
-func (s *Server) handleAddRecipient(c *gin.Context) {
-	id := c.Param("id")
-	var req struct {
-		UserId string `json:"user_id"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil || req.UserId == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "user_id is required"})
-		return
-	}
-	// Check duplicate
-	var existing internal.NotifyRecipient
-	if err := s.repo.DB().Where("project_id = ? AND user_id = ?", id, req.UserId).First(&existing).Error; err == nil {
-		c.JSON(http.StatusConflict, gin.H{"error": "Recipient already exists"})
-		return
-	}
-	recipient := internal.NotifyRecipient{ProjectId: id, UserId: req.UserId}
-	if err := s.repo.AddNotifyRecipient(recipient); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"id": recipient.Id, "project_id": id, "user_id": req.UserId})
-}
-
-func (s *Server) handleRemoveRecipient(c *gin.Context) {
-	id := c.Param("id")
-	rid, err := strconv.ParseInt(c.Param("rid"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid recipient id"})
-		return
-	}
-	if err := s.repo.RemoveNotifyRecipient(id, rid); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"ok": true})
-}
-
-func (s *Server) handleListCCWebhooks(c *gin.Context) {
-	id := c.Param("id")
-	webhooks, err := s.repo.ListCCWebhooks(id)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"webhooks": webhooks})
-}
-
-func (s *Server) handleAddCCWebhook(c *gin.Context) {
-	id := c.Param("id")
-	var req struct {
-		WebhookUrl  string `json:"webhook_url"`
-		Description string `json:"description"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil || req.WebhookUrl == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "webhook_url is required"})
-		return
-	}
-	webhook := internal.CCWebhook{ProjectId: id, WebhookUrl: req.WebhookUrl, Description: req.Description}
-	if err := s.repo.AddCCWebhook(webhook); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"id": webhook.Id, "project_id": id, "webhook_url": req.WebhookUrl, "description": req.Description})
-}
-
-func (s *Server) handleRemoveCCWebhook(c *gin.Context) {
-	id := c.Param("id")
-	wid, err := strconv.ParseInt(c.Param("wid"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid webhook id"})
-		return
-	}
-	if err := s.repo.RemoveCCWebhook(id, wid); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
 func (s *Server) handleRegister(c *gin.Context) {
@@ -387,7 +292,7 @@ func (s *Server) handleReport(c *gin.Context) {
 			if status.SourceUrl != "" {
 				content += fmt.Sprintf("\n📎 源码: %s", status.SourceUrl)
 			}
-			s.sendNotifications(dbJob.ProjectId, title, content)
+			s.sendJobNotifications(parseNotify(dbJob.Notify), title, content)
 		}
 		finalPhase := "Succeeded"
 		if status.Failed > 0 {
@@ -621,22 +526,21 @@ func (s *Server) handleWebhook(c *gin.Context) {
 			ProjectId: id,
 			Name:      createdJob.Name,
 			Status:    "",
+			Notify:    marshalNotify(job.Notify),
 		}); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
 		jobs = append(jobs, createdJob.Name)
-	}
 
-	// Notify recipients: pipeline triggered
-	if len(jobs) > 0 {
-		statusUrl := fmt.Sprintf("%s/#/status/%s", s.config.Host, jobs[0])
+		// Notify this job's targets: pipeline triggered
+		statusUrl := fmt.Sprintf("%s/#/status/%s", s.config.Host, createdJob.Name)
 		title := "🚀 流水线触发通知"
-		content := fmt.Sprintf("📂 项目: %s\n🔄 触发: %s\n🔗 查看: %s", webhookConfig.RepoUrl, ph.trigger, statusUrl)
+		content := fmt.Sprintf("📂 项目: %s\n📋 任务: %s\n🔄 触发: %s\n🔗 查看: %s", webhookConfig.RepoUrl, createdJob.Name, ph.trigger, statusUrl)
 		if ph.sourceUrl != "" {
 			content += fmt.Sprintf("\n📎 源码: %s", ph.sourceUrl)
 		}
-		s.sendNotifications(id, title, content)
+		s.sendJobNotifications(job.Notify, title, content)
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "pipeline": ph.pipeline, "jobs": jobs})
@@ -732,6 +636,7 @@ func (s *Server) handleTrigger(c *gin.Context) {
 		ProjectId: project.Id,
 		Name:      createdJob.Name,
 		Status:    "",
+		Notify:    marshalNotify(job.Notify),
 	}); err != nil {
 		log.Printf("failed to save job to database: %v", err)
 	}
@@ -740,7 +645,7 @@ func (s *Server) handleTrigger(c *gin.Context) {
 	statusUrl := fmt.Sprintf("%s/#/status/%s", s.config.Host, createdJob.Name)
 	title := "🚀 流水线触发通知 (API)"
 	content := fmt.Sprintf("📂 项目: %s\n📋 作业: %s\n🏷️ Ref: %s\n🔗 查看: %s", req.RepoUrl, req.JobName, req.Ref, statusUrl)
-	s.sendNotifications(project.Id, title, content)
+	s.sendJobNotifications(job.Notify, title, content)
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":   "ok",
@@ -782,4 +687,30 @@ func codeRefForTrigger(trigger, ref string) string {
 		return ""
 	}
 	return parser.ExtractRefName(ref)
+}
+
+// marshalNotify serializes a job's notify config to JSON for persistence on
+// neutron_job. A nil config yields an empty string.
+func marshalNotify(n *model.Notify) string {
+	if n == nil {
+		return ""
+	}
+	b, err := json.Marshal(n)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// parseNotify deserializes the notify config persisted on neutron_job. An empty
+// or invalid value yields nil (no notifications).
+func parseNotify(s string) *model.Notify {
+	if s == "" {
+		return nil
+	}
+	var n model.Notify
+	if err := json.Unmarshal([]byte(s), &n); err != nil {
+		return nil
+	}
+	return &n
 }

--- a/cmd/api/static/index.html
+++ b/cmd/api/static/index.html
@@ -455,6 +455,12 @@
                 '  build:                              # Job name\n' +
                 '    image: maven:3.9-eclipse-temurin-17  # Docker image\n' +
                 '    trigger: [PUSH, MR]                # Trigger events\n' +
+                '    notify:                            # Optional per-job notifications\n' +
+                '      users:                           # IM personal message recipients\n' +
+                '        - zhangsan\n' +
+                '        - lisi\n' +
+                '      groups:                          # CCWork group robot webhook URLs\n' +
+                '        - "https://ccwork.example.com/robot/send?key=order-dev"\n' +
                 '    resources:                         # Optional resource limits\n' +
                 '      limits:\n' +
                 '        cpu: "2"\n' +
@@ -483,6 +489,8 @@
                     '<tbody>' +
                         '<tr><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>image</code></td><td style="padding:8px;border-bottom:1px solid #f3f4f6">Docker image for the job</td><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>node:18</code></td></tr>' +
                         '<tr><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>trigger</code></td><td style="padding:8px;border-bottom:1px solid #f3f4f6">Events that trigger the job</td><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>[PUSH, MR, TAG]</code></td></tr>' +
+                        '<tr><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>notify.users</code></td><td style="padding:8px;border-bottom:1px solid #f3f4f6">IM 个人消息接收者 (user id)</td><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>[zhangsan, lisi]</code></td></tr>' +
+                        '<tr><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>notify.groups</code></td><td style="padding:8px;border-bottom:1px solid #f3f4f6">群机器人 webhook URL（群通知）</td><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>["https://.../robot/send?key=..."]</code></td></tr>' +
                         '<tr><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>resources.limits.cpu</code></td><td style="padding:8px;border-bottom:1px solid #f3f4f6">Maximum CPU cores</td><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>"2"</code>, <code>"500m"</code></td></tr>' +
                         '<tr><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>resources.limits.memory</code></td><td style="padding:8px;border-bottom:1px solid #f3f4f6">Maximum memory</td><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>"4Gi"</code>, <code>"512Mi"</code></td></tr>' +
                         '<tr><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>resources.requests.cpu</code></td><td style="padding:8px;border-bottom:1px solid #f3f4f6">Requested CPU cores</td><td style="padding:8px;border-bottom:1px solid #f3f4f6"><code>"500m"</code></td></tr>' +
@@ -656,9 +664,7 @@
 
         Promise.all([
             fetch('/api/projects').then(function(r) { return r.json(); }),
-            fetch('/api/projects/' + encodeURIComponent(projectId) + '/jobs').then(function(r) { return r.json(); }),
-            fetch('/api/projects/' + encodeURIComponent(projectId) + '/recipients').then(function(r) { return r.json(); }),
-            fetch('/api/projects/' + encodeURIComponent(projectId) + '/ccwebhooks').then(function(r) { return r.json(); })
+            fetch('/api/projects/' + encodeURIComponent(projectId) + '/jobs').then(function(r) { return r.json(); })
         ]).then(function(results) {
             var projects = results[0].projects || [];
             var project = null;
@@ -666,7 +672,7 @@
                 if (projects[i].Id === projectId) { project = projects[i]; break; }
             }
 
-            // Display project info + recipients tags + ccwebhook tags
+            // Display project info
             var infoEl = document.getElementById('projectInfo');
             if (project) {
                 var httpUrl = sshToHttp(project.RepoUrl, project.WebhookType);
@@ -674,34 +680,17 @@
                 var repoHtml = httpUrl
                     ? '<a target="_blank" href="' + escAttr(httpUrl) + '">' + escHtml(project.RepoUrl) + '</a>'
                     : escHtml(project.RepoUrl);
-                var recipients = results[2].recipients || [];
-                var tagsHtml = '';
-                for (var i = 0; i < recipients.length; i++) {
-                    tagsHtml += '<span class="tag">' + escHtml(recipients[i].user_id) + '</span>';
-                }
-                tagsHtml += '<span class="tag-add" onclick="openRecipientsModal(\'' + escAttr(projectId) + '\')">+ Edit</span>';
-                var webhooks = results[3].webhooks || [];
-                var webhookTagsHtml = '';
-                for (var i = 0; i < webhooks.length; i++) {
-                    webhookTagsHtml += '<span class="tag" title="' + escAttr(webhooks[i].webhook_url) + '">' + escHtml(webhooks[i].description || 'Webhook ' + webhooks[i].id) + '</span>';
-                }
-                webhookTagsHtml += '<span class="tag-add" onclick="openCCWebhooksModal(\'' + escAttr(projectId) + '\')">+ Edit</span>';
                 infoEl.innerHTML =
                     '<div class="card" style="margin-bottom:16px">' +
                         '<div style="display:flex;align-items:center;gap:8px;margin-bottom:12px">' +
                             '<span style="font-size:1.6rem;font-weight:700;color:#2d3748">' + escHtml(repoName) + '</span>' +
                             '<span style="font-size:1.2rem;font-weight:600;color:#999;text-transform:uppercase;letter-spacing:.5px;margin-left:8px">' + escHtml(project.WebhookType) + '</span>' +
                         '</div>' +
-                        '<div style="margin-bottom:12px">' +
+                        '<div>' +
                             '<span style="font-size:1.3rem;color:#606c76">' + repoHtml + '</span>' +
                         '</div>' +
-                        '<div style="border-top:1px solid #f3f4f6;padding-top:12px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
-                            '<span style="font-size:1.2rem;font-weight:600;color:#999;text-transform:uppercase;letter-spacing:.5px">Notify</span>' +
-                            '<div id="projectRecipientTags" style="display:flex;flex-wrap:wrap;align-items:center;gap:6px">' + tagsHtml + '</div>' +
-                        '</div>' +
-                        '<div style="border-top:1px solid #f3f4f6;padding-top:12px;margin-top:12px;display:flex;align-items:center;gap:8px;flex-wrap:wrap">' +
-                            '<span style="font-size:1.2rem;font-weight:600;color:#999;text-transform:uppercase;letter-spacing:.5px">群通知</span>' +
-                            '<div id="projectCCWebhookTags" style="display:flex;flex-wrap:wrap;align-items:center;gap:6px">' + webhookTagsHtml + '</div>' +
+                        '<div style="border-top:1px solid #f3f4f6;padding-top:12px;margin-top:12px;font-size:1.3rem;color:#999">' +
+                            '通知策略已迁移至仓库内 <code>neutron.yaml</code> 的各 job <code>notify</code> 配置（见 <a href="#/help">帮助</a>）。' +
                         '</div>' +
                     '</div>';
             }
@@ -716,245 +705,6 @@
         }).catch(function(err) {
             document.getElementById('jobsList').innerHTML = '<p style="color:#c00">Failed to load: ' + escHtml(String(err)) + '</p>';
         });
-    }
-
-    // --- Recipients Modal ---
-    function openRecipientsModal(projectId) {
-        // Overlay
-        var overlay = document.createElement('div');
-        overlay.className = 'modal-overlay';
-        overlay.id = 'recipientsModal';
-        overlay.onclick = function(e) { if (e.target === overlay) overlay.remove(); };
-
-        var modal = document.createElement('div');
-        modal.className = 'modal';
-        modal.innerHTML =
-            '<h4>Notification Recipients</h4>' +
-            '<div id="modalRecipientsList"><p style="color:#999;font-size:1.3rem">Loading...</p></div>' +
-            '<div class="modal-input-row">' +
-                '<input type="text" id="modalRecipientInput" placeholder="Enter user ID...">' +
-                '<button class="btn btn-outline" id="modalAddBtn" style="margin:0;padding:8px 16px;font-size:1.3rem">Add</button>' +
-            '</div>';
-        overlay.appendChild(modal);
-        document.body.appendChild(overlay);
-
-        function refreshModalList() {
-            fetch('/api/projects/' + encodeURIComponent(projectId) + '/recipients')
-                .then(function(r) { return r.json(); })
-                .then(function(data) {
-                    var list = data.recipients || [];
-                    var el = document.getElementById('modalRecipientsList');
-                    if (!el) return;
-                    if (list.length === 0) {
-                        el.innerHTML = '<p style="color:#999;font-size:1.3rem">No recipients configured.</p>';
-                    } else {
-                        var html = '';
-                        for (var i = 0; i < list.length; i++) {
-                            html += '<div style="display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #f3f4f6">' +
-                                '<span style="font-size:1.4rem;color:#222">' + escHtml(list[i].user_id) + '</span>' +
-                                '<a href="javascript:void(0)" style="color:#dc2626;font-size:1.2rem;font-weight:600" ' +
-                                'onclick="removeRecipientFromModal(\'' + escAttr(projectId) + '\',' + list[i].id + ')">Remove</a></div>';
-                        }
-                        el.innerHTML = html;
-                    }
-                });
-        }
-        refreshModalList();
-
-        var btn = document.getElementById('modalAddBtn');
-        var input = document.getElementById('modalRecipientInput');
-        btn.onclick = function() {
-            var userId = input.value.trim();
-            if (!userId) return;
-            fetch('/api/projects/' + encodeURIComponent(projectId) + '/recipients', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ user_id: userId })
-            })
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                if (data.error) { alert(data.error); return; }
-                input.value = '';
-                refreshModalList();
-                refreshProjectTags(projectId);
-            })
-            .catch(function(err) { alert('Request failed: ' + err); });
-        };
-        input.onkeydown = function(e) { if (e.key === 'Enter') btn.onclick(); };
-        input.focus();
-    }
-    window.openRecipientsModal = openRecipientsModal;
-
-    // --- CCWebhooks Modal ---
-    function openCCWebhooksModal(projectId) {
-        var overlay = document.createElement('div');
-        overlay.className = 'modal-overlay';
-        overlay.id = 'ccwebhooksModal';
-        overlay.onclick = function(e) { if (e.target === overlay) overlay.remove(); };
-
-        var modal = document.createElement('div');
-        modal.className = 'modal';
-        modal.style.maxWidth = '520px';
-        modal.innerHTML =
-            '<h4>群通知 Webhook</h4>' +
-            '<div id="modalCCWebhooksList"><p style="color:#999;font-size:1.3rem">Loading...</p></div>' +
-            '<div style="margin-top:16px">' +
-                '<div class="modal-input-row">' +
-                    '<input type="text" id="modalWebhookUrl" placeholder="Webhook URL">' +
-                '</div>' +
-                '<div class="modal-input-row">' +
-                    '<input type="text" id="modalWebhookDesc" placeholder="描述 (如: 前端开发群)">' +
-                    '<button class="btn btn-outline" id="modalAddWebhookBtn" style="margin:0;padding:8px 16px;font-size:1.3rem">Add</button>' +
-                '</div>' +
-            '</div>';
-        overlay.appendChild(modal);
-        document.body.appendChild(overlay);
-
-        function refreshModalList() {
-            fetch('/api/projects/' + encodeURIComponent(projectId) + '/ccwebhooks')
-                .then(function(r) { return r.json(); })
-                .then(function(data) {
-                    var list = data.webhooks || [];
-                    var el = document.getElementById('modalCCWebhooksList');
-                    if (!el) return;
-                    if (list.length === 0) {
-                        el.innerHTML = '<p style="color:#999;font-size:1.3rem">No webhooks configured.</p>';
-                    } else {
-                        var html = '';
-                        for (var i = 0; i < list.length; i++) {
-                            html += '<div style="display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #f3f4f6">' +
-                                '<div style="flex:1;min-width:0">' +
-                                    '<div style="font-size:1.4rem;color:#222;font-weight:600">' + escHtml(list[i].description || 'Webhook ' + list[i].id) + '</div>' +
-                                    '<div style="font-size:1.2rem;color:#999;word-break:break-all">' + escHtml(list[i].webhook_url) + '</div>' +
-                                '</div>' +
-                                '<a href="javascript:void(0)" style="color:#dc2626;font-size:1.2rem;font-weight:600;margin-left:12px;flex-shrink:0" ' +
-                                'onclick="removeCCWebhookFromModal(\'' + escAttr(projectId) + '\',' + list[i].id + ')">Remove</a></div>';
-                        }
-                        el.innerHTML = html;
-                    }
-                });
-        }
-        refreshModalList();
-
-        var btn = document.getElementById('modalAddWebhookBtn');
-        var urlInput = document.getElementById('modalWebhookUrl');
-        var descInput = document.getElementById('modalWebhookDesc');
-        btn.onclick = function() {
-            var webhookUrl = urlInput.value.trim();
-            if (!webhookUrl) { alert('Please enter a webhook URL'); return; }
-            var description = descInput.value.trim();
-            fetch('/api/projects/' + encodeURIComponent(projectId) + '/ccwebhooks', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ webhook_url: webhookUrl, description: description })
-            })
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                if (data.error) { alert(data.error); return; }
-                urlInput.value = '';
-                descInput.value = '';
-                refreshModalList();
-                refreshCCWebhookTags(projectId);
-            })
-            .catch(function(err) { alert('Request failed: ' + err); });
-        };
-        descInput.onkeydown = function(e) { if (e.key === 'Enter') btn.onclick(); };
-        urlInput.focus();
-    }
-    window.openCCWebhooksModal = openCCWebhooksModal;
-
-    function removeCCWebhookFromModal(projectId, wid) {
-        fetch('/api/projects/' + encodeURIComponent(projectId) + '/ccwebhooks/' + wid, { method: 'DELETE' })
-            .then(function(r) { return r.json(); })
-            .then(function() {
-                var el = document.getElementById('modalCCWebhooksList');
-                if (el) {
-                    fetch('/api/projects/' + encodeURIComponent(projectId) + '/ccwebhooks')
-                        .then(function(r) { return r.json(); })
-                        .then(function(data) {
-                            var list = data.webhooks || [];
-                            if (list.length === 0) {
-                                el.innerHTML = '<p style="color:#999;font-size:1.3rem">No webhooks configured.</p>';
-                            } else {
-                                var html = '';
-                                for (var i = 0; i < list.length; i++) {
-                                    html += '<div style="display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #f3f4f6">' +
-                                        '<div style="flex:1;min-width:0">' +
-                                            '<div style="font-size:1.4rem;color:#222;font-weight:600">' + escHtml(list[i].description || 'Webhook ' + list[i].id) + '</div>' +
-                                            '<div style="font-size:1.2rem;color:#999;word-break:break-all">' + escHtml(list[i].webhook_url) + '</div>' +
-                                        '</div>' +
-                                        '<a href="javascript:void(0)" style="color:#dc2626;font-size:1.2rem;font-weight:600;margin-left:12px;flex-shrink:0" ' +
-                                        'onclick="removeCCWebhookFromModal(\'' + escAttr(projectId) + '\',' + list[i].id + ')">Remove</a></div>';
-                                }
-                                el.innerHTML = html;
-                            }
-                        });
-                }
-                refreshCCWebhookTags(projectId);
-            });
-    }
-    window.removeCCWebhookFromModal = removeCCWebhookFromModal;
-
-    function refreshCCWebhookTags(projectId) {
-        fetch('/api/projects/' + encodeURIComponent(projectId) + '/ccwebhooks')
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                var tagsEl = document.getElementById('projectCCWebhookTags');
-                if (!tagsEl) return;
-                var webhooks = data.webhooks || [];
-                var html = '';
-                for (var i = 0; i < webhooks.length; i++) {
-                    html += '<span class="tag" title="' + escAttr(webhooks[i].webhook_url) + '">' + escHtml(webhooks[i].description || 'Webhook ' + webhooks[i].id) + '</span>';
-                }
-                html += '<span class="tag-add" onclick="openCCWebhooksModal(\'' + escAttr(projectId) + '\')">+ Edit</span>';
-                tagsEl.innerHTML = html;
-            });
-    }
-
-    function removeRecipientFromModal(projectId, rid) {
-        fetch('/api/projects/' + encodeURIComponent(projectId) + '/recipients/' + rid, { method: 'DELETE' })
-            .then(function(r) { return r.json(); })
-            .then(function() {
-                // Refresh modal list
-                var el = document.getElementById('modalRecipientsList');
-                if (el) {
-                    fetch('/api/projects/' + encodeURIComponent(projectId) + '/recipients')
-                        .then(function(r) { return r.json(); })
-                        .then(function(data) {
-                            var list = data.recipients || [];
-                            if (list.length === 0) {
-                                el.innerHTML = '<p style="color:#999;font-size:1.3rem">No recipients configured.</p>';
-                            } else {
-                                var html = '';
-                                for (var i = 0; i < list.length; i++) {
-                                    html += '<div style="display:flex;justify-content:space-between;align-items:center;padding:8px 0;border-bottom:1px solid #f3f4f6">' +
-                                        '<span style="font-size:1.4rem;color:#222">' + escHtml(list[i].user_id) + '</span>' +
-                                        '<a href="javascript:void(0)" style="color:#dc2626;font-size:1.2rem;font-weight:600" ' +
-                                        'onclick="removeRecipientFromModal(\'' + escAttr(projectId) + '\',' + list[i].id + ')">Remove</a></div>';
-                                }
-                                el.innerHTML = html;
-                            }
-                        });
-                }
-                refreshProjectTags(projectId);
-            });
-    }
-    window.removeRecipientFromModal = removeRecipientFromModal;
-
-    function refreshProjectTags(projectId) {
-        fetch('/api/projects/' + encodeURIComponent(projectId) + '/recipients')
-            .then(function(r) { return r.json(); })
-            .then(function(data) {
-                var tagsEl = document.getElementById('projectRecipientTags');
-                if (!tagsEl) return;
-                var recipients = data.recipients || [];
-                var html = '';
-                for (var i = 0; i < recipients.length; i++) {
-                    html += '<span class="tag">' + escHtml(recipients[i].user_id) + '</span>';
-                }
-                html += '<span class="tag-add" onclick="openRecipientsModal(\'' + escAttr(projectId) + '\')">+ Edit</span>';
-                tagsEl.innerHTML = html;
-            });
     }
 
     function renderProjectJobsList(jobs) {

--- a/internal/model/pipeline.go
+++ b/internal/model/pipeline.go
@@ -9,6 +9,14 @@ type Job struct {
 	Trigger   []string   `yaml:"trigger"`
 	Steps     []Step     `yaml:"steps"`
 	Resources *Resources `yaml:"resources,omitempty"`
+	Notify    *Notify    `yaml:"notify,omitempty"`
+}
+
+// Notify declares the per-job notification targets. Both fields are optional;
+// an empty or absent Notify block means the job sends no notifications.
+type Notify struct {
+	Users  []string `yaml:"users,omitempty" json:"users,omitempty"`   // IM personal message recipients (user ids)
+	Groups []string `yaml:"groups,omitempty" json:"groups,omitempty"` // CCWork group robot webhook URLs
 }
 
 type Step struct {

--- a/internal/repo.go
+++ b/internal/repo.go
@@ -23,12 +23,13 @@ func (PipelineProject) TableName() string {
 }
 
 type PipelineJob struct {
-	Id          int64        `gorm:"column:id;primaryKey;autoIncrement"`
-	ProjectId   string       `gorm:"column:project_id"`
-	Name        string       `gorm:"column:name;type:varchar(255);uniqueIndex"`
-	Status      string       `gorm:"column:status;type:text"`
-	Completed   bool         `gorm:"column:completed;default:false"`
-	CompletedAt *time.Time   `gorm:"column:completed_at"`
+	Id          int64         `gorm:"column:id;primaryKey;autoIncrement"`
+	ProjectId   string        `gorm:"column:project_id"`
+	Name        string        `gorm:"column:name;type:varchar(255);uniqueIndex"`
+	Status      string        `gorm:"column:status;type:text"`
+	Notify      string        `gorm:"column:notify;type:text"` // JSON-encoded model.Notify, captured at trigger time
+	Completed   bool          `gorm:"column:completed;default:false"`
+	CompletedAt *time.Time    `gorm:"column:completed_at"`
 	Pods        []PipelinePod `gorm:"foreignKey:JobId"`
 }
 
@@ -46,29 +47,6 @@ type PipelinePod struct {
 
 func (PipelinePod) TableName() string {
 	return "neutron_pod"
-}
-
-type NotifyRecipient struct {
-	Id        int64      `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	ProjectId string     `gorm:"column:project_id;type:char(36);uniqueIndex:idx_project_user" json:"project_id"`
-	UserId    string     `gorm:"column:user_id;type:varchar(100);uniqueIndex:idx_project_user" json:"user_id"`
-	CreatedAt *time.Time `gorm:"column:created_at" json:"created_at"`
-}
-
-func (NotifyRecipient) TableName() string {
-	return "neutron_notify"
-}
-
-type CCWebhook struct {
-	Id          int64      `gorm:"column:id;primaryKey;autoIncrement" json:"id"`
-	ProjectId   string     `gorm:"column:project_id;type:char(36);index" json:"project_id"`
-	WebhookUrl  string     `gorm:"column:webhook_url;type:varchar(500)" json:"webhook_url"`
-	Description string     `gorm:"column:description;type:varchar(200)" json:"description"`
-	CreatedAt   *time.Time `gorm:"column:created_at" json:"created_at"`
-}
-
-func (CCWebhook) TableName() string {
-	return "neutron_ccwebhook"
 }
 
 type JobReport struct {
@@ -107,7 +85,7 @@ func NewRepository(config model.Config) *Repository {
 	}
 
 	// Auto-migrate tables
-	if err := db.AutoMigrate(&PipelineProject{}, &PipelineJob{}, &PipelinePod{}, &NotifyRecipient{}, &CCWebhook{}, &JobReport{}); err != nil {
+	if err := db.AutoMigrate(&PipelineProject{}, &PipelineJob{}, &PipelinePod{}, &JobReport{}); err != nil {
 		log.Fatalf("failed to auto-migrate database: %v", err)
 	}
 
@@ -219,34 +197,6 @@ func (r *Repository) MarkJobCompleted(jobName string) error {
 			"completed":    true,
 			"completed_at": now,
 		}).Error
-}
-
-func (r *Repository) ListNotifyRecipients(projectId string) ([]NotifyRecipient, error) {
-	var recipients []NotifyRecipient
-	err := r.db.Where("project_id = ?", projectId).Order("id").Find(&recipients).Error
-	return recipients, err
-}
-
-func (r *Repository) AddNotifyRecipient(recipient NotifyRecipient) error {
-	return r.db.Create(&recipient).Error
-}
-
-func (r *Repository) RemoveNotifyRecipient(projectId string, id int64) error {
-	return r.db.Where("project_id = ? AND id = ?", projectId, id).Delete(&NotifyRecipient{}).Error
-}
-
-func (r *Repository) ListCCWebhooks(projectId string) ([]CCWebhook, error) {
-	var webhooks []CCWebhook
-	err := r.db.Where("project_id = ?", projectId).Order("id").Find(&webhooks).Error
-	return webhooks, err
-}
-
-func (r *Repository) AddCCWebhook(webhook CCWebhook) error {
-	return r.db.Create(&webhook).Error
-}
-
-func (r *Repository) RemoveCCWebhook(projectId string, id int64) error {
-	return r.db.Where("project_id = ? AND id = ?", projectId, id).Delete(&CCWebhook{}).Error
 }
 
 func (r *Repository) SetJobReportUrl(jobName string, reportUrl string) error {


### PR DESCRIPTION
## 概述

把通知配置从「DB / 按项目」迁移到「neutron.yaml / 按 job」，让不同 job 可以配置不同的通知目标。每个 job 的 `notify` 块声明 IM 个人接收者和/或群机器人 webhook URL（群通知复用现有 `ccwork.Robot`）。

```yaml
jobs:
  build:
    trigger: [PUSH, MR]
    notify:
      users:  [zhangsan, lisi]                          # IM 个人消息
      groups: ["https://ccwork.example.com/robot/send?key=order-dev"]  # 群通知
```

`users` / `groups` 均可选；整个 `notify` 缺省则该 job 不发通知。

## 设计

**核心难点**：流水线完成时 `handleReport` 只拿到 jobName，没有 neutron.yaml。

**解法**：触发时把 job 的 notify 序列化为 JSON 存进 `neutron_job` 新增的 `notify` 列；完成时顺着 `handleReport` **本就在调用**的 `GetJobByName` 读回 —— 零额外查询，且不受 K8s Job 被清理 / TTL 影响（K8s annotation 在完成时不可靠，DB 才是已完成 job 的事实源）。

- `model.Job` 新增可选 `*Notify{Users, Groups}`。
- `sendNotifications(projectId,...)` → `sendJobNotifications(*model.Notify,...)`：按 user 发 IM、按 group URL 发 CCWork webhook，保留 fire-and-forget goroutine 语义。
- 三个调用点全部切换：`handleWebhook` 改为在 job 创建循环内**按 job**发触发通知；`handleReport` 读 `dbJob.Notify`；`handleTrigger` 用被触发 job 的 `Notify`。
- 新增 `marshalNotify` / `parseNotify` 两个序列化 helper。

## 删除（配置已移入 neutron.yaml）

- DB 模型 `NotifyRecipient` / `CCWebhook` 及其 6 个 Repository 方法，从 AutoMigrate 移除。
- 6 条 API 路由（`/api/projects/:id/recipients|ccwebhooks ...`）及对应 handler。
- 前端 recipients / ccwebhooks 管理弹窗、项目页的 Notify / 群通知 标签区；项目详情页改为只拉 projects + jobs。
- Help 页补充 notify 块示例 + `notify.users` / `notify.groups` 配置说明。
- `CLAUDE.md` 同步更新（路由清单、表结构、Notifications 一节）。

## 行为变化（有意为之，需评审关注）

1. **触发通知改为按 job**：每个配置了 notify 的 job 各发一条触发通知；没配 notify 的 job 不发。原先是「每 webhook 一条、发给项目接收者」。→ 一次 push 触发多个 job 时会有多条触发消息。
2. **项目级 DB 通知配置及管理 UI 移除**：存量 `neutron_notify` / `neutron_ccwebhook` 行失效。

## 升级 / 迁移指引 ⚠️

本次为破坏性变更，升级后**已有的项目级通知配置不会自动迁移、会静默失效**。运维步骤：

1. **重新声明通知**：在每个仓库的 `neutron.yaml` 里，为需要通知的 job 添加 `notify` 块（users / groups），替代原先在 UI 里按项目配置的接收者与群 webhook。原 `neutron_ccwebhook` 表里的群 webhook URL 可直接搬进对应 job 的 `notify.groups`。
2. **清理孤儿表**（可选）：`neutron_notify` / `neutron_ccwebhook` 两表不再被任何代码读写，GORM 也不会自动 drop。确认无其他依赖后可手动清理：
   ```sql
   DROP TABLE IF EXISTS neutron_notify;
   DROP TABLE IF EXISTS neutron_ccwebhook;
   ```
3. **在途 job 边界**：升级前已创建、升级后才完成的 job，其 `notify` 列为空 → 不发完成通知。属一次性边界，可忽略。

`neutron_job.notify` 列由 `AutoMigrate` 自动添加，无需手工建列。

## 验证

- ✅ `go build ./...` / `go vet ./...` / `go test ./...` 全绿；`make api/gitlab/codeup` 三个二进制构建成功。
- ✅ 本地 podman + MySQL 起服务：AutoMigrate 给 `neutron_job` 加出 `notify` 列、不再创建 `neutron_notify` / `neutron_ccwebhook` 两表。
- ✅ **抓包实证**：往 `neutron_job` 插带 notify JSON 的行后 POST 完成报告，本地捕获服务收到群 webhook 请求，attachment 内容正确（title `✅ 流水线执行成功` + 项目/任务/查看）—— 证明配置确实从 notify 列读回并派发。
- ✅ 前端项目详情页不再出现 recipients/ccwebhooks 管理 UI；Help 页展示新 notify 示例；JS 通过 `node --check`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
