### PR TITLE
feat: job 重跑能力（从持久化 spec 重建 K8s Job）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ go test ./...
 - `GET /api/status/:jobName` — job/pod status (JSON, from DB for completed jobs or K8s API for active jobs)
 - `POST /api/report/:jobName` — runners push status back to API server for persistence
 - `POST /api/report/:jobName/link` — set a test report URL for a job (`{"report_url": "..."}`)
+- `POST /api/jobs/:jobName/rerun` — rerun a webhook-created job by recreating an identical K8s Job from its persisted spec (same commit/params/trigger, reports to platform like the original). Only jobs with a stored spec are rerunnable.
 - SPA: `cmd/api/static/index.html` — vanilla JS with hash-based routing (#/, #/projects, #/project/:id, #/status/:name)
 
 **GitLab Runner** (`cmd/gitlab-runner/`) — runs inside K8s pods for GitLab projects:
@@ -76,7 +77,7 @@ go test ./...
 
 Tables auto-migrated by GORM:
 - `neutron_project` (id, webhook_type, repo_url)
-- `neutron_job` (id, project_id, name, status, notify, completed, completed_at) — `notify` is JSON-encoded `model.Notify` captured from the job's `neutron.yaml` at trigger time
+- `neutron_job` (id, project_id, name, status, notify, spec, completed, completed_at) — `notify` is JSON-encoded `model.Notify`; `spec` is JSON-encoded `model.JobSpec` (rerun snapshot), captured from the job's `neutron.yaml`/webhook at trigger time
 - `neutron_pod` (id, job_id, pod_name, pod_uid, phase)
 - `neutron_job_report` (id, job_name, report_url, created_at) — test report link per job
 

--- a/cmd/api/rerun_verify_test.go
+++ b/cmd/api/rerun_verify_test.go
@@ -1,97 +1,117 @@
 package main
 
 import (
-	"context"
 	"strings"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"neutron/internal/model"
 )
 
-func TestCreateJobFromSpecRebuild(t *testing.T) {
-	cs := fake.NewSimpleClientset()
-	cfg := model.Config{}
+// TestLauncherFromSpecRebuild verifies that the production manifest-construction
+// path (Server.launcherFromSpec → buildLauncher → launcher.CreateJob) rebuilds a
+// K8s Job carrying every input persisted in a JobSpec: annotations, env vars
+// (including webhook query params), and a checkout pinned to the exact commit.
+func TestLauncherFromSpecRebuild(t *testing.T) {
+	cfg := model.Config{Host: "http://neutron.local"}
 	cfg.Kubernetes.Namespace = "default"
 	cfg.BaseConfig = map[string]model.CodeBase{
 		"GitLab": {Url: "https://gitlab.example.com", Token: "tok", SkipTLSVerify: true},
 	}
-	cfg.Host = "http://neutron.local"
-
-	// repo backed by in-memory sqlite is overkill; use the real repo only if needed.
-	// Here we only exercise the K8s manifest construction, so a nil repo would panic on AddJob.
-	// Use a sqlite-less shim: skip AddJob by checking the created K8s Job before persistence.
-	srv := &Server{config: cfg, clientSet: cs, repo: nil}
+	srv := &Server{config: cfg, clientSet: fake.NewSimpleClientset()}
 
 	spec := model.JobSpec{
-		Platform:     "GitLab",
-		JobName:      "build",
-		Image:        "maven:3.9",
-		ProjectId:    "101",
-		CommitSha:    "abc123def",
-		ReportSha:    "abc123def",
-		Trigger:      "PUSH",
-		GitRepoUrl:   "git@gitlab.example.com:backend/order-service.git",
-		CodeRef:      "main",
-		SourceUrl:    "https://gitlab.example.com/backend/order-service/-/tree/main",
-		QueryParams:  map[string]string{"DEPLOY_ENV": "prod"},
+		Platform:    "GitLab",
+		JobName:     "build",
+		Image:       "maven:3.9",
+		ProjectId:   "101",
+		CommitSha:   "abc123def",
+		ReportSha:   "abc123def",
+		Trigger:     "PUSH",
+		GitRepoUrl:  "git@gitlab.example.com:backend/order-service.git",
+		CodeRef:     "main",
+		SourceUrl:   "https://gitlab.example.com/backend/order-service/-/tree/main",
+		QueryParams: map[string]string{"DEPLOY_ENV": "prod"},
 	}
 
-	// createJobFromSpec calls repo.AddJob; to isolate manifest building we replicate
-	// the launcher call the same way and assert on the K8s Job object.
-	baseCfg := srv.config.BaseConfig[spec.Platform]
-	rc := model.RunnerConfig{
-		CodebaseToken: baseCfg.Token, CodebaseUrl: baseCfg.Url,
-		ProjectId: spec.ProjectId, CommitSha: spec.CommitSha, ReportSha: spec.ReportSha,
-		JobName: spec.JobName, Trigger: spec.Trigger, GitRepoUrl: spec.GitRepoUrl,
-		GitPrivateKey: "/etc/ssh/id_rsa", CodeRef: spec.CodeRef, SourceUrl: spec.SourceUrl,
-	}
-	var extra []v1.EnvVar
-	extra = append(extra, v1.EnvVar{Name: "RUNNER_PLATFORM", Value: strings.ToLower(spec.Platform)})
-	if baseCfg.SkipTLSVerify {
-		extra = append(extra, v1.EnvVar{Name: "SKIP_TLS_VERIFY", Value: "true"})
-	}
-	for k, val := range spec.QueryParams {
-		extra = append(extra, v1.EnvVar{Name: k, Value: val})
-	}
-	l := srv.buildLauncher(rc, spec.Image, spec.Resources, spec.Platform, extra)
-	job := l.CreateJob(srv.config.Host)
+	job := srv.launcherFromSpec(spec).CreateJob(srv.config.Host)
 
-	created, err := cs.BatchV1().Jobs("default").Create(context.Background(), job, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("create: %v", err)
+	if !strings.HasPrefix(job.Name, "neutron-build-") {
+		t.Errorf("job name = %q, want neutron-build-*", job.Name)
 	}
-	if !strings.HasPrefix(created.Name, "neutron-build-") {
-		t.Errorf("job name = %q, want neutron-build-*", created.Name)
+	if got := job.Annotations["triggerType"]; got != "PUSH" {
+		t.Errorf("annotation triggerType = %q, want PUSH", got)
 	}
-	if created.Annotations["triggerType"] != "PUSH" {
-		t.Errorf("triggerType = %q", created.Annotations["triggerType"])
+	if got := job.Annotations["sourceUrl"]; got != spec.SourceUrl {
+		t.Errorf("annotation sourceUrl = %q, want %q", got, spec.SourceUrl)
 	}
-	if created.Annotations["sourceUrl"] != spec.SourceUrl {
-		t.Errorf("sourceUrl = %q", created.Annotations["sourceUrl"])
+	if got := job.Annotations["gitPath"]; got != spec.GitRepoUrl {
+		t.Errorf("annotation gitPath = %q, want %q", got, spec.GitRepoUrl)
 	}
-	if created.Annotations["gitPath"] != spec.GitRepoUrl {
-		t.Errorf("gitPath = %q", created.Annotations["gitPath"])
+	if got := job.Spec.Template.Spec.Containers[0].Image; got != spec.Image {
+		t.Errorf("image = %q, want %q", got, spec.Image)
 	}
+
 	env := map[string]string{}
-	for _, e := range created.Spec.Template.Spec.Containers[0].Env {
+	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
 		env[e.Name] = e.Value
 	}
 	for k, want := range map[string]string{
 		"COMMIT_SHA": "abc123def", "REPORT_SHA": "abc123def", "TRIGGER": "PUSH",
-		"CODE_REF": "main", "DEPLOY_ENV": "prod", "RUNNER_PLATFORM": "gitlab",
-		"SKIP_TLS_VERIFY": "true",
+		"CODE_REF": "main", "PROJECT_ID": "101", "DEPLOY_ENV": "prod",
+		"RUNNER_PLATFORM": "gitlab", "SKIP_TLS_VERIFY": "true",
 	} {
 		if env[k] != want {
 			t.Errorf("env[%s] = %q, want %q", k, env[k], want)
 		}
 	}
-	// checkout container should clone + checkout the exact commit
-	checkout := created.Spec.Template.Spec.InitContainers[0].Command[2]
+	// non-MR checkout clones and checks out the exact commit (no merge).
+	checkout := job.Spec.Template.Spec.InitContainers[0].Command[2]
 	if !strings.Contains(checkout, "abc123def") {
 		t.Errorf("checkout cmd missing commit: %q", checkout)
+	}
+	if strings.Contains(checkout, "merge") {
+		t.Errorf("non-MR checkout should not merge: %q", checkout)
+	}
+}
+
+// TestLauncherFromSpecMR covers the GitLab MR branch: TARGET_BRANCH env is set
+// and the checkout merges the source commit into the target branch.
+func TestLauncherFromSpecMR(t *testing.T) {
+	cfg := model.Config{Host: "http://neutron.local"}
+	cfg.Kubernetes.Namespace = "default"
+	cfg.BaseConfig = map[string]model.CodeBase{
+		"GitLab": {Url: "https://gitlab.example.com", Token: "tok"},
+	}
+	srv := &Server{config: cfg, clientSet: fake.NewSimpleClientset()}
+
+	spec := model.JobSpec{
+		Platform:     "GitLab",
+		JobName:      "test",
+		Image:        "node:18",
+		ProjectId:    "7",
+		CommitSha:    "deadbeef",
+		ReportSha:    "deadbeef",
+		Trigger:      "MR",
+		GitRepoUrl:   "git@gitlab.example.com:web/portal.git",
+		TargetBranch: "develop",
+	}
+
+	job := srv.launcherFromSpec(spec).CreateJob(srv.config.Host)
+
+	env := map[string]string{}
+	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
+		env[e.Name] = e.Value
+	}
+	if env["TARGET_BRANCH"] != "develop" {
+		t.Errorf("env[TARGET_BRANCH] = %q, want develop", env["TARGET_BRANCH"])
+	}
+	if env["SKIP_TLS_VERIFY"] != "" {
+		t.Errorf("env[SKIP_TLS_VERIFY] = %q, want empty (TLS verify on)", env["SKIP_TLS_VERIFY"])
+	}
+	checkout := job.Spec.Template.Spec.InitContainers[0].Command[2]
+	if !strings.Contains(checkout, "develop") || !strings.Contains(checkout, "merge") {
+		t.Errorf("MR checkout should clone target branch and merge: %q", checkout)
 	}
 }

--- a/cmd/api/rerun_verify_test.go
+++ b/cmd/api/rerun_verify_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"neutron/internal/model"
+)
+
+func TestCreateJobFromSpecRebuild(t *testing.T) {
+	cs := fake.NewSimpleClientset()
+	cfg := model.Config{}
+	cfg.Kubernetes.Namespace = "default"
+	cfg.BaseConfig = map[string]model.CodeBase{
+		"GitLab": {Url: "https://gitlab.example.com", Token: "tok", SkipTLSVerify: true},
+	}
+	cfg.Host = "http://neutron.local"
+
+	// repo backed by in-memory sqlite is overkill; use the real repo only if needed.
+	// Here we only exercise the K8s manifest construction, so a nil repo would panic on AddJob.
+	// Use a sqlite-less shim: skip AddJob by checking the created K8s Job before persistence.
+	srv := &Server{config: cfg, clientSet: cs, repo: nil}
+
+	spec := model.JobSpec{
+		Platform:     "GitLab",
+		JobName:      "build",
+		Image:        "maven:3.9",
+		ProjectId:    "101",
+		CommitSha:    "abc123def",
+		ReportSha:    "abc123def",
+		Trigger:      "PUSH",
+		GitRepoUrl:   "git@gitlab.example.com:backend/order-service.git",
+		CodeRef:      "main",
+		SourceUrl:    "https://gitlab.example.com/backend/order-service/-/tree/main",
+		QueryParams:  map[string]string{"DEPLOY_ENV": "prod"},
+	}
+
+	// createJobFromSpec calls repo.AddJob; to isolate manifest building we replicate
+	// the launcher call the same way and assert on the K8s Job object.
+	baseCfg := srv.config.BaseConfig[spec.Platform]
+	rc := model.RunnerConfig{
+		CodebaseToken: baseCfg.Token, CodebaseUrl: baseCfg.Url,
+		ProjectId: spec.ProjectId, CommitSha: spec.CommitSha, ReportSha: spec.ReportSha,
+		JobName: spec.JobName, Trigger: spec.Trigger, GitRepoUrl: spec.GitRepoUrl,
+		GitPrivateKey: "/etc/ssh/id_rsa", CodeRef: spec.CodeRef, SourceUrl: spec.SourceUrl,
+	}
+	var extra []v1.EnvVar
+	extra = append(extra, v1.EnvVar{Name: "RUNNER_PLATFORM", Value: strings.ToLower(spec.Platform)})
+	if baseCfg.SkipTLSVerify {
+		extra = append(extra, v1.EnvVar{Name: "SKIP_TLS_VERIFY", Value: "true"})
+	}
+	for k, val := range spec.QueryParams {
+		extra = append(extra, v1.EnvVar{Name: k, Value: val})
+	}
+	l := srv.buildLauncher(rc, spec.Image, spec.Resources, spec.Platform, extra)
+	job := l.CreateJob(srv.config.Host)
+
+	created, err := cs.BatchV1().Jobs("default").Create(context.Background(), job, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !strings.HasPrefix(created.Name, "neutron-build-") {
+		t.Errorf("job name = %q, want neutron-build-*", created.Name)
+	}
+	if created.Annotations["triggerType"] != "PUSH" {
+		t.Errorf("triggerType = %q", created.Annotations["triggerType"])
+	}
+	if created.Annotations["sourceUrl"] != spec.SourceUrl {
+		t.Errorf("sourceUrl = %q", created.Annotations["sourceUrl"])
+	}
+	if created.Annotations["gitPath"] != spec.GitRepoUrl {
+		t.Errorf("gitPath = %q", created.Annotations["gitPath"])
+	}
+	env := map[string]string{}
+	for _, e := range created.Spec.Template.Spec.Containers[0].Env {
+		env[e.Name] = e.Value
+	}
+	for k, want := range map[string]string{
+		"COMMIT_SHA": "abc123def", "REPORT_SHA": "abc123def", "TRIGGER": "PUSH",
+		"CODE_REF": "main", "DEPLOY_ENV": "prod", "RUNNER_PLATFORM": "gitlab",
+		"SKIP_TLS_VERIFY": "true",
+	} {
+		if env[k] != want {
+			t.Errorf("env[%s] = %q, want %q", k, env[k], want)
+		}
+	}
+	// checkout container should clone + checkout the exact commit
+	checkout := created.Spec.Template.Spec.InitContainers[0].Command[2]
+	if !strings.Contains(checkout, "abc123def") {
+		t.Errorf("checkout cmd missing commit: %q", checkout)
+	}
+}

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -58,6 +59,7 @@ func (s *Server) registerRoutes(r *gin.Engine) {
 	r.POST("/api/report/:jobName", s.handleReport)
 	r.POST("/api/report/:jobName/pod", s.handleReportPod)
 	r.POST("/api/report/:jobName/link", s.handleReportLink)
+	r.POST("/api/jobs/:jobName/rerun", s.handleRerun)
 	r.POST("/webhook/:id", s.handleWebhook)
 	r.POST("/api/trigger", s.handleTrigger)
 }
@@ -147,12 +149,13 @@ func (s *Server) handleStatus(c *gin.Context) {
 			reportUrl = url
 		}
 		c.JSON(http.StatusOK, gin.H{
-			"jobName":   jobName,
-			"status":    status,
-			"job":       gin.H{"metadata": gin.H{"name": jobName}},
-			"pods":      gin.H{"items": podItems},
-			"source":    "database",
-			"reportUrl": reportUrl,
+			"jobName":    jobName,
+			"status":     status,
+			"job":        gin.H{"metadata": gin.H{"name": jobName}},
+			"pods":       gin.H{"items": podItems},
+			"source":     "database",
+			"reportUrl":  reportUrl,
+			"rerunnable": dbJob.Spec != "",
 		})
 		return
 	}
@@ -228,12 +231,13 @@ func (s *Server) handleStatus(c *gin.Context) {
 		reportUrl = url
 	}
 	c.JSON(http.StatusOK, gin.H{
-		"jobName":   jobName,
-		"status":    k8sStatus,
-		"job":       job,
-		"pods":      pods,
-		"source":    "kubernetes",
-		"reportUrl": reportUrl,
+		"jobName":    jobName,
+		"status":     k8sStatus,
+		"job":        job,
+		"pods":       pods,
+		"source":     "kubernetes",
+		"reportUrl":  reportUrl,
+		"rerunnable": dbErr == nil && dbJob.Spec != "",
 	})
 }
 
@@ -391,6 +395,50 @@ func (s *Server) handleReportLink(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
+// handleRerun reruns a previously webhook-created job by recreating an
+// identical K8s Job from its persisted spec (same commit, params, and trigger,
+// so it reports to the platform like the original run). It produces a new job
+// record; the original is untouched.
+func (s *Server) handleRerun(c *gin.Context) {
+	jobName := c.Param("jobName")
+
+	dbJob, err := s.repo.GetJobByName(jobName)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "job not found"})
+		return
+	}
+	spec, ok := parseSpec(dbJob.Spec)
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "job is not rerunnable (no spec; only webhook jobs can be rerun)"})
+		return
+	}
+	if _, ok := s.config.BaseConfig[spec.Platform]; !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s codebase not configured", spec.Platform)})
+		return
+	}
+
+	createdName, err := s.createJobFromSpec(dbJob.ProjectId, spec, parseNotify(dbJob.Notify))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to rerun job: %v", err)})
+		return
+	}
+
+	// Notify the job's targets: rerun triggered
+	statusUrl := fmt.Sprintf("%s/#/status/%s", s.config.Host, createdName)
+	title := "🔁 流水线重跑通知"
+	content := fmt.Sprintf("📂 项目: %s\n📋 任务: %s\n♻️ 重跑自: %s\n🔄 触发: %s\n🔗 查看: %s", spec.GitRepoUrl, createdName, jobName, spec.Trigger, statusUrl)
+	if spec.SourceUrl != "" {
+		content += fmt.Sprintf("\n📎 源码: %s", spec.SourceUrl)
+	}
+	s.sendJobNotifications(parseNotify(dbJob.Notify), title, content)
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":   "ok",
+		"job_name": createdName,
+		"job_url":  statusUrl,
+	})
+}
+
 // parsedHook holds the platform-agnostic result of parsing an incoming webhook.
 type parsedHook struct {
 	pipeline     model.Pipeline
@@ -480,63 +528,34 @@ func (s *Server) handleWebhook(c *gin.Context) {
 			continue
 		}
 
-		// resolve codebase config (pod override if available)
-		baseCfg := s.config.BaseConfig[platform]
-		if pod, ok := s.config.PodCodeBase[platform]; ok {
-			baseCfg = pod
+		// Build the rerun snapshot from this webhook's parsed inputs.
+		spec := model.JobSpec{
+			Platform:     platform,
+			JobName:      jobName,
+			Image:        job.Image,
+			Resources:    job.Resources,
+			ProjectId:    strconv.Itoa(ph.projectId),
+			CommitSha:    ph.codeSha,
+			ReportSha:    ph.reportSha,
+			Trigger:      ph.trigger,
+			GitRepoUrl:   webhookConfig.RepoUrl,
+			TargetBranch: ph.targetBranch,
+			CodeRef:      ph.codeRef,
+			SourceUrl:    ph.sourceUrl,
+			QueryParams:  firstQueryValues(c.Request.URL.Query()),
 		}
 
-		runnerConfig := model.RunnerConfig{
-			CodebaseToken: baseCfg.Token,
-			CodebaseUrl:   baseCfg.Url,
-			ProjectId:     strconv.Itoa(ph.projectId),
-			CommitSha:     ph.codeSha,
-			ReportSha:     ph.reportSha,
-			JobName:       jobName,
-			Trigger:       ph.trigger,
-			GitRepoUrl:    webhookConfig.RepoUrl,
-			GitPrivateKey: "/etc/ssh/id_rsa",
-			TargetBranch:  ph.targetBranch,
-			CodeRef:       ph.codeRef,
-			SourceUrl:     ph.sourceUrl,
-		}
-
-		// platform-specific extra env vars
-		var extraEnv []v1.EnvVar
-		extraEnv = append(extraEnv, v1.EnvVar{Name: "RUNNER_PLATFORM", Value: strings.ToLower(platform)})
-		if baseCfg.SkipTLSVerify {
-			extraEnv = append(extraEnv, v1.EnvVar{Name: "SKIP_TLS_VERIFY", Value: "true"})
-		}
-		if platform == "GitLab" && ph.targetBranch != "" {
-			extraEnv = append(extraEnv, v1.EnvVar{Name: "TARGET_BRANCH", Value: ph.targetBranch})
-		}
-		// pass webhook URL query params as env vars to the pod
-		for key, values := range c.Request.URL.Query() {
-			extraEnv = append(extraEnv, v1.EnvVar{Name: key, Value: values[0]})
-		}
-
-		l := s.buildLauncher(runnerConfig, job.Image, job.Resources, platform, extraEnv)
-		jobClient := s.clientSet.BatchV1().Jobs(s.config.Kubernetes.Namespace)
-		createdJob, err := jobClient.Create(context.Background(), l.CreateJob(s.config.Host), metav1.CreateOptions{})
+		createdName, err := s.createJobFromSpec(id, spec, job.Notify)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		if err := s.repo.AddJob(internal.PipelineJob{
-			ProjectId: id,
-			Name:      createdJob.Name,
-			Status:    "",
-			Notify:    marshalNotify(job.Notify),
-		}); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-		jobs = append(jobs, createdJob.Name)
+		jobs = append(jobs, createdName)
 
 		// Notify this job's targets: pipeline triggered
-		statusUrl := fmt.Sprintf("%s/#/status/%s", s.config.Host, createdJob.Name)
+		statusUrl := fmt.Sprintf("%s/#/status/%s", s.config.Host, createdName)
 		title := "🚀 流水线触发通知"
-		content := fmt.Sprintf("📂 项目: %s\n📋 任务: %s\n🔄 触发: %s\n🔗 查看: %s", webhookConfig.RepoUrl, createdJob.Name, ph.trigger, statusUrl)
+		content := fmt.Sprintf("📂 项目: %s\n📋 任务: %s\n🔄 触发: %s\n🔗 查看: %s", webhookConfig.RepoUrl, createdName, ph.trigger, statusUrl)
 		if ph.sourceUrl != "" {
 			content += fmt.Sprintf("\n📎 源码: %s", ph.sourceUrl)
 		}
@@ -544,6 +563,62 @@ func (s *Server) handleWebhook(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "pipeline": ph.pipeline, "jobs": jobs})
+}
+
+// createJobFromSpec rebuilds the RunnerConfig + extra env from a JobSpec,
+// creates the K8s Job, and persists the DB row carrying the same spec (so the
+// job can be rerun again). Returns the generated K8s Job name. Tokens/URLs are
+// resolved from the current config rather than the spec.
+func (s *Server) createJobFromSpec(projectId string, spec model.JobSpec, notify *model.Notify) (string, error) {
+	platform := spec.Platform
+	baseCfg := s.config.BaseConfig[platform]
+	if pod, ok := s.config.PodCodeBase[platform]; ok {
+		baseCfg = pod
+	}
+
+	runnerConfig := model.RunnerConfig{
+		CodebaseToken: baseCfg.Token,
+		CodebaseUrl:   baseCfg.Url,
+		ProjectId:     spec.ProjectId,
+		CommitSha:     spec.CommitSha,
+		ReportSha:     spec.ReportSha,
+		JobName:       spec.JobName,
+		Trigger:       spec.Trigger,
+		GitRepoUrl:    spec.GitRepoUrl,
+		GitPrivateKey: "/etc/ssh/id_rsa",
+		TargetBranch:  spec.TargetBranch,
+		CodeRef:       spec.CodeRef,
+		SourceUrl:     spec.SourceUrl,
+	}
+
+	var extraEnv []v1.EnvVar
+	extraEnv = append(extraEnv, v1.EnvVar{Name: "RUNNER_PLATFORM", Value: strings.ToLower(platform)})
+	if baseCfg.SkipTLSVerify {
+		extraEnv = append(extraEnv, v1.EnvVar{Name: "SKIP_TLS_VERIFY", Value: "true"})
+	}
+	if platform == "GitLab" && spec.TargetBranch != "" {
+		extraEnv = append(extraEnv, v1.EnvVar{Name: "TARGET_BRANCH", Value: spec.TargetBranch})
+	}
+	for key, value := range spec.QueryParams {
+		extraEnv = append(extraEnv, v1.EnvVar{Name: key, Value: value})
+	}
+
+	l := s.buildLauncher(runnerConfig, spec.Image, spec.Resources, platform, extraEnv)
+	jobClient := s.clientSet.BatchV1().Jobs(s.config.Kubernetes.Namespace)
+	createdJob, err := jobClient.Create(context.Background(), l.CreateJob(s.config.Host), metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+	if err := s.repo.AddJob(internal.PipelineJob{
+		ProjectId: projectId,
+		Name:      createdJob.Name,
+		Status:    "",
+		Notify:    marshalNotify(notify),
+		Spec:      marshalSpec(spec),
+	}); err != nil {
+		return "", err
+	}
+	return createdJob.Name, nil
 }
 
 func (s *Server) handleTrigger(c *gin.Context) {
@@ -713,4 +788,42 @@ func parseNotify(s string) *model.Notify {
 		return nil
 	}
 	return &n
+}
+
+// marshalSpec serializes a job's rerun spec to JSON for persistence on
+// neutron_job. A marshal error yields an empty string (job becomes non-rerunnable).
+func marshalSpec(spec model.JobSpec) string {
+	b, err := json.Marshal(spec)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// parseSpec deserializes the rerun spec persisted on neutron_job. An empty or
+// invalid value yields ok=false.
+func parseSpec(s string) (model.JobSpec, bool) {
+	var spec model.JobSpec
+	if s == "" {
+		return spec, false
+	}
+	if err := json.Unmarshal([]byte(s), &spec); err != nil {
+		return spec, false
+	}
+	return spec, true
+}
+
+// firstQueryValues flattens url.Values to a single value per key, matching the
+// webhook handler's original behaviour of taking values[0].
+func firstQueryValues(q url.Values) map[string]string {
+	if len(q) == 0 {
+		return nil
+	}
+	m := make(map[string]string, len(q))
+	for key, values := range q {
+		if len(values) > 0 {
+			m[key] = values[0]
+		}
+	}
+	return m
 }

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -417,9 +417,10 @@ func (s *Server) handleRerun(c *gin.Context) {
 		return
 	}
 
-	createdName, err := s.createJobFromSpec(dbJob.ProjectId, spec, parseNotify(dbJob.Notify))
+	notify := parseNotify(dbJob.Notify)
+	createdName, err := s.createJobFromSpec(dbJob.ProjectId, spec, notify)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to rerun job: %v", err)})
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to rerun job: %v", err)})
 		return
 	}
 
@@ -430,7 +431,7 @@ func (s *Server) handleRerun(c *gin.Context) {
 	if spec.SourceUrl != "" {
 		content += fmt.Sprintf("\n📎 源码: %s", spec.SourceUrl)
 	}
-	s.sendJobNotifications(parseNotify(dbJob.Notify), title, content)
+	s.sendJobNotifications(notify, title, content)
 
 	c.JSON(http.StatusOK, gin.H{
 		"status":   "ok",
@@ -565,11 +566,11 @@ func (s *Server) handleWebhook(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok", "pipeline": ph.pipeline, "jobs": jobs})
 }
 
-// createJobFromSpec rebuilds the RunnerConfig + extra env from a JobSpec,
-// creates the K8s Job, and persists the DB row carrying the same spec (so the
-// job can be rerun again). Returns the generated K8s Job name. Tokens/URLs are
-// resolved from the current config rather than the spec.
-func (s *Server) createJobFromSpec(projectId string, spec model.JobSpec, notify *model.Notify) (string, error) {
+// launcherFromSpec rebuilds the RunnerConfig + extra env from a JobSpec and
+// returns a configured launcher. Tokens/URLs are resolved from the current
+// config (not the spec). This is the pure manifest-construction step shared by
+// the webhook and rerun paths; it has no side effects, so it is unit-testable.
+func (s *Server) launcherFromSpec(spec model.JobSpec) *launcher.Launcher {
 	platform := spec.Platform
 	baseCfg := s.config.BaseConfig[platform]
 	if pod, ok := s.config.PodCodeBase[platform]; ok {
@@ -603,7 +604,14 @@ func (s *Server) createJobFromSpec(projectId string, spec model.JobSpec, notify 
 		extraEnv = append(extraEnv, v1.EnvVar{Name: key, Value: value})
 	}
 
-	l := s.buildLauncher(runnerConfig, spec.Image, spec.Resources, platform, extraEnv)
+	return s.buildLauncher(runnerConfig, spec.Image, spec.Resources, platform, extraEnv)
+}
+
+// createJobFromSpec builds the K8s Job from a JobSpec (via launcherFromSpec),
+// creates it, and persists the DB row carrying the same spec (so the job can be
+// rerun again). Returns the generated K8s Job name.
+func (s *Server) createJobFromSpec(projectId string, spec model.JobSpec, notify *model.Notify) (string, error) {
+	l := s.launcherFromSpec(spec)
 	jobClient := s.clientSet.BatchV1().Jobs(s.config.Kubernetes.Namespace)
 	createdJob, err := jobClient.Create(context.Background(), l.CreateJob(s.config.Host), metav1.CreateOptions{})
 	if err != nil {

--- a/cmd/api/static/index.html
+++ b/cmd/api/static/index.html
@@ -859,17 +859,18 @@
                     return;
                 }
                 // Always use renderStatusLive since we now always have job and pods
-                renderStatusLive(data.job, data.pods, data.status, data.reportUrl);
+                renderStatusLive(data.job, data.pods, data.status, data.reportUrl, data.rerunnable);
             })
             .catch(function(err) {
                 app.innerHTML = '<p class="page-title">Error</p><p>' + escHtml(String(err)) + '</p>';
             });
     }
 
-    function renderStatusLive(job, podsData, dbStatus, reportUrl) {
+    function renderStatusLive(job, podsData, dbStatus, reportUrl, rerunnable) {
         var ann = job && job.metadata && job.metadata.annotations ? job.metadata.annotations : {};
         var st = job ? (job.status || {}) : {};
         var items = podsData && podsData.items ? podsData.items : [];
+        var jobName = job && job.metadata ? job.metadata.name : '';
 
         // Use database status if available, otherwise derive from K8s
         // Note: dbStatus uses lowercase keys (from JSON), K8s uses PascalCase
@@ -895,7 +896,7 @@
         }
 
         app.innerHTML =
-            '<p class="page-title">Job &mdash; <b>' + escHtml(job && job.metadata ? job.metadata.name : '') + '</b></p>' +
+            '<p class="page-title">Job &mdash; <b>' + escHtml(jobName) + '</b></p>' +
             '<div class="card">' +
                 '<div class="meta">' +
                     '<div>A <b>' + escHtml(webhookType) + '</b> &rarr; <b>' + escHtml(triggerType) + '</b> pipeline</div>' +
@@ -910,9 +911,26 @@
                     '<table><thead><tr><th>Pod</th><th>Status</th></tr></thead><tbody>' + podsHtml + '</tbody></table>'
                     : '<p style="color:#999;margin-top:12px">No pods found.</p>') +
                 (appConfig.logUrl ? '<p class="log-hint">Click pod name to view logs on external platform</p>' : '') +
-                (reportUrl ? '<div style="margin-top:16px"><a target="_blank" href="' + escAttr(reportUrl) + '" class="btn btn-outline" style="padding:6px 16px;font-size:1.3rem">Test Report</a></div>' : '') +
+                ((reportUrl || rerunnable) ?
+                    '<div style="margin-top:16px;display:flex;gap:12px;align-items:center">' +
+                        (reportUrl ? '<a target="_blank" href="' + escAttr(reportUrl) + '" class="btn btn-outline" style="padding:6px 16px;font-size:1.3rem">Test Report</a>' : '') +
+                        (rerunnable ? '<button class="btn btn-outline" style="padding:6px 16px;font-size:1.3rem" onclick="rerunJob(\'' + escAttr(jobName) + '\')">🔁 重跑</button>' : '') +
+                    '</div>'
+                    : '') +
             '</div>';
     }
+
+    function rerunJob(jobName) {
+        if (!confirm('确认重跑该任务？将以相同的提交和参数重新运行一次。')) return;
+        fetch('/api/jobs/' + encodeURIComponent(jobName) + '/rerun', { method: 'POST' })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.error) { alert(data.error); return; }
+                location.hash = '#/status/' + data.job_name;
+            })
+            .catch(function(err) { alert('重跑失败: ' + err); });
+    }
+    window.rerunJob = rerunJob;
 
     // --- Utils ---
     function escHtml(s) {

--- a/internal/model/pipeline.go
+++ b/internal/model/pipeline.go
@@ -19,6 +19,27 @@ type Notify struct {
 	Groups []string `yaml:"groups,omitempty" json:"groups,omitempty"` // CCWork group robot webhook URLs
 }
 
+// JobSpec is the persisted snapshot of a webhook-created job's inputs, kept on
+// the DB row so an identical K8s Job can be recreated later (rerun). Tokens are
+// intentionally NOT stored — they are re-resolved from config at rerun time.
+// Steps are not stored either — the runner reads neutron.yaml from the same
+// immutable commit, so the same file is reproduced exactly.
+type JobSpec struct {
+	Platform     string            `json:"platform"`               // GitLab / Codeup
+	JobName      string            `json:"job_name"`               // pipeline job key (e.g. "build")
+	Image        string            `json:"image"`
+	Resources    *Resources        `json:"resources,omitempty"`
+	ProjectId    string            `json:"project_id"`             // RunnerConfig.ProjectId (numeric string)
+	CommitSha    string            `json:"commit_sha"`
+	ReportSha    string            `json:"report_sha"`
+	Trigger      string            `json:"trigger"`                // PUSH / MR / TAG
+	GitRepoUrl   string            `json:"git_repo_url"`
+	TargetBranch string            `json:"target_branch,omitempty"`
+	CodeRef      string            `json:"code_ref,omitempty"`
+	SourceUrl    string            `json:"source_url,omitempty"`
+	QueryParams  map[string]string `json:"query_params,omitempty"` // webhook URL query params → pod env
+}
+
 type Step struct {
 	StepName string `yaml:"name"`
 	Command  string `yaml:"cmd"`

--- a/internal/repo.go
+++ b/internal/repo.go
@@ -28,6 +28,7 @@ type PipelineJob struct {
 	Name        string        `gorm:"column:name;type:varchar(255);uniqueIndex"`
 	Status      string        `gorm:"column:status;type:text"`
 	Notify      string        `gorm:"column:notify;type:text"` // JSON-encoded model.Notify, captured at trigger time
+	Spec        string        `gorm:"column:spec;type:text"`   // JSON-encoded model.JobSpec for rerun; empty for API-triggered jobs
 	Completed   bool          `gorm:"column:completed;default:false"`
 	CompletedAt *time.Time    `gorm:"column:completed_at"`
 	Pods        []PipelinePod `gorm:"foreignKey:JobId"`


### PR DESCRIPTION
## 概述

为 job 增加「重跑」能力：从持久化的输入快照重建一个完全一致的 K8s Job。面向**外部/环境原因导致失败后的重跑**——同一 commit、同一参数、同一 trigger，因此会像首次那样向 GitLab/Codeup 上报 commit status。

```
POST /api/jobs/:jobName/rerun
```

## 设计

**核心难点**：流水线完成后，重跑所需的 commitSha/reportSha/targetBranch/codeRef/sourceUrl/webhook query params/image/resources 这些输入既不在 DB 也不可靠地在 K8s。

**解法**：首次创建 webhook job 时，把这些输入快照成 `model.JobSpec`，JSON 存进 `neutron_job` 新增的 `spec` 列（与 `notify`/`status` 同款）。重跑时反序列化、原样重建。

- **token 不入库**：spec 只存 platform，重跑时从当前 config 取 token/url（不存敏感凭证、不会用到过期凭证）。
- **neutron.yaml 不重拉**：steps 由 runner 在 checkout 出的**同一不可变 commit** 上读仓库内文件——同 commit = 同文件，精确复现且不依赖平台 API。
- **抽取 `createJobFromSpec`**：handleWebhook 的 per-job 创建逻辑抽成此函数，webhook 路径与重跑共用 → 保证重跑的 K8s Job 与首次逐字一致（仅时间戳/名字不同）。
- **刻意保留上报**：`createJobFromSpec` 不设 SkipTriggerCheck/SkipPlatformReport（区别于 `/api/trigger`），所以重跑会向平台上报。

## 改动

- `internal/model/pipeline.go` — 新增 `JobSpec` 类型。
- `internal/repo.go` — `PipelineJob` 加 `spec` 列（AutoMigrate 自动加）。
- `cmd/api/server.go` — 抽取 `createJobFromSpec`；改造 `handleWebhook` 组装 spec；新增 `handleRerun` + 路由；`handleStatus` 两处响应加 `rerunnable` 标志；`marshalSpec`/`parseSpec`/`firstQueryValues` helper。
- `cmd/api/static/index.html` — 状态详情页加「🔁 重跑」按钮（仅 `rerunnable` 时显示）+ `rerunJob`。
- `cmd/api/rerun_verify_test.go` — **新增测试**（fake clientset），断言重建的 Job manifest：annotations、env（含 query_params→pod env）、checkout 命令锁定精确 commit。也是该仓库首个覆盖 K8s Job 构造的测试。
- `CLAUDE.md` — 同步新路由 + spec 列。

## 行为说明

- 仅 webhook job 可重跑（有 spec）；API-triggered job 与升级前已存在的旧 job（spec 为空）不可重跑 → `400`，详情页不显示按钮。
- 重跑创建**新 job 行**、不覆盖原 job；新 job 自带相同 spec → 可再次重跑，历史可追溯。
- **「逐字节一致」以 config 未变为前提**：token / codebase url / skip_tls_verify 不入快照，重跑时从当前 `config.BaseConfig` 重新解析（刻意为之——不存敏感凭证、不用过期凭证）。若运维在两次运行之间改了 codebase 配置，重建的 Job 会随之不同（如 `SKIP_TLS_VERIFY` env、`sourceLink` annotation）。
- runner / launcher / notify 无需改动。

## 验证

- ✅ `go build ./...` / `go vet ./...` / `go test ./...` 全绿；`make api/gitlab/codeup` 成功。
- ✅ **单元测试实证**重建的 K8s Job manifest 正确（annotations + env 含 `DEPLOY_ENV` 来自 query_params + checkout 锁定 commit `abc123def`）。
- ✅ 本地 podman + MySQL 端到端：AutoMigrate 加出 `spec` 列；`GET /api/status` 返回 `rerunnable` 正确（有 spec=true / 无=false）；`rerun` 对缺失 job→`404`、无 spec→`400`（正确文案）、有 spec→走到 K8s Create 并用重建的 manifest；完成通知抓包正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

